### PR TITLE
1.2.12 (2026-04-02)

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,7 +4,7 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="corretto-11" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/src/main/java/fr/inserm/u1078/tludwig/vcfprocessor/files/variants/BCFByteArray.java
+++ b/src/main/java/fr/inserm/u1078/tludwig/vcfprocessor/files/variants/BCFByteArray.java
@@ -44,7 +44,7 @@ public class BCFByteArray extends ByteArray {
     boolean allMissing = true;
     for(int i = 0 ; i < ad.getLength(); i++) {
       int v = readInt(ad.getType());
-      if( v == 0)
+      if( v <= 0)
         sValues[i] = ".";
       else if(convert(v) == 63)
         sValues[i] = "remove";
@@ -72,7 +72,7 @@ public class BCFByteArray extends ByteArray {
   }
 
   public static int convert(int v){
-    return (((v&0xFE) >> 1)-1);
+    return (((v/*&0xFE*/) >> 1)-1);
   }
 
   /**

--- a/src/main/java/fr/inserm/u1078/tludwig/vcfprocessor/files/variants/BCFByteArray.java
+++ b/src/main/java/fr/inserm/u1078/tludwig/vcfprocessor/files/variants/BCFByteArray.java
@@ -42,9 +42,11 @@ public class BCFByteArray extends ByteArray {
     String[] sValues = new String[ad.getLength()];
     String phased = "/";
     boolean allMissing = true;
+    String debug = "";
     for(int i = 0 ; i < ad.getLength(); i++) {
       int v = readInt(ad.getType());
-      if( v <= 0)
+      debug += ";"+v;
+      if( v == 0)
         sValues[i] = ".";
       else if(convert(v) == 63)
         sValues[i] = "remove";
@@ -60,6 +62,7 @@ public class BCFByteArray extends ByteArray {
         }
       }
     }
+
     if(allMissing)
       return ".";
 
@@ -67,6 +70,8 @@ public class BCFByteArray extends ByteArray {
     for(int i = 1; i < sValues.length; i++)
       if(!sValues[i].equals("remove"))
         ret.append(phased).append(sValues[i]);
+
+    Message.debug(ret.toString().startsWith("0|-1"), "Genotype "+debug);
 
     return ret.toString();
   }

--- a/src/main/java/fr/inserm/u1078/tludwig/vcfprocessor/files/variants/BCFByteArray.java
+++ b/src/main/java/fr/inserm/u1078/tludwig/vcfprocessor/files/variants/BCFByteArray.java
@@ -41,44 +41,42 @@ public class BCFByteArray extends ByteArray {
   public String readGTValues(ArrayDescription ad) throws BCFException {
     String[] sValues = new String[ad.getLength()];
     String phased = "/";
-    boolean allMissing = true;
-    String debug = "";
+    //boolean allMissing = true;
     for(int i = 0 ; i < ad.getLength(); i++) {
-      int v = readInt(ad.getType());
-      debug += ";"+v;
-      if( v == 0)
-        sValues[i] = ".";
-      else if(convert(v) == 63)
+      final int v = readInt(ad.getType());
+      final int convert = convert(v);
+
+      if(convert >= 63) {
         sValues[i] = "remove";
-      else {
-        allMissing = false;
-        if(v % 2 == 1)
+        Message.error("Error in genotypes");
+        Message.error(ad.toString());
+        Message.die("error in genotypes");
+      } else {
+        if (v % 2 == 1)
           phased = "|";
-        sValues[i] = "" + convert(v);
-        if(sValues[i].equals("63")){
-          Message.error("Error in genotypes");
-          Message.error(ad.toString());
-          Message.die("error in genotypes");
+        if(convert == -1)
+          sValues[i] = ".";
+        else {
+          //allMissing = false;
+          sValues[i] = "" + convert;
         }
       }
     }
 
-    if(allMissing)
-      return ".";
+    /*if(allMissing)
+      return ".";*/
 
     StringBuilder ret = new StringBuilder(sValues[0]);
     for(int i = 1; i < sValues.length; i++)
       if(!sValues[i].equals("remove"))
         ret.append(phased).append(sValues[i]);
 
-    Message.debug(ret.toString().startsWith("0|-1"), "Genotype "+debug);
-
     return ret.toString();
   }
 
-  public static int convert(int v){
-    return (((v&0xFE) >> 1)-1);
-  }
+  public static int convert(int v){ return (((v/*&0xFE*/) >> 1)-1); }
+
+  public static int convert2(int v){ return (((v&0xFE) >> 1)-1); }
 
   /**
    * Reads values form a Genotype Field

--- a/src/main/java/fr/inserm/u1078/tludwig/vcfprocessor/files/variants/BCFByteArray.java
+++ b/src/main/java/fr/inserm/u1078/tludwig/vcfprocessor/files/variants/BCFByteArray.java
@@ -72,7 +72,7 @@ public class BCFByteArray extends ByteArray {
   }
 
   public static int convert(int v){
-    return (((v/*&0xFE*/) >> 1)-1);
+    return (((v&0xFE) >> 1)-1);
   }
 
   /**

--- a/src/main/java/fr/inserm/u1078/tludwig/vcfprocessor/files/variants/BCFByteArray.java
+++ b/src/main/java/fr/inserm/u1078/tludwig/vcfprocessor/files/variants/BCFByteArray.java
@@ -41,7 +41,7 @@ public class BCFByteArray extends ByteArray {
   public String readGTValues(ArrayDescription ad) throws BCFException {
     String[] sValues = new String[ad.getLength()];
     String phased = "/";
-    //boolean allMissing = true;
+
     for(int i = 0 ; i < ad.getLength(); i++) {
       final int v = readInt(ad.getType());
       final int convert = convert(v);
@@ -54,17 +54,11 @@ public class BCFByteArray extends ByteArray {
       } else {
         if (v % 2 == 1)
           phased = "|";
-        if(convert == -1)
-          sValues[i] = ".";
-        else {
-          //allMissing = false;
-          sValues[i] = "" + convert;
-        }
+        sValues[i] = convert == -1
+            ? "."
+            : "" + convert;
       }
     }
-
-    /*if(allMissing)
-      return ".";*/
 
     StringBuilder ret = new StringBuilder(sValues[0]);
     for(int i = 1; i < sValues.length; i++)
@@ -75,8 +69,6 @@ public class BCFByteArray extends ByteArray {
   }
 
   public static int convert(int v){ return (((v/*&0xFE*/) >> 1)-1); }
-
-  public static int convert2(int v){ return (((v&0xFE) >> 1)-1); }
 
   /**
    * Reads values form a Genotype Field

--- a/src/main/java/fr/inserm/u1078/tludwig/vcfprocessor/files/variants/VCF.java
+++ b/src/main/java/fr/inserm/u1078/tludwig/vcfprocessor/files/variants/VCF.java
@@ -827,7 +827,7 @@ public class VCF implements VariantProducer {
     private final String type;
     private final int number;
 
-    public static final int NUMBER_ALLELES = -9;
+    public static final int NUMBER_ALLELES = -9; //TODO use enum ?
     public static final int NUMBER_ALTS = -8;
     public static final int NUMBER_GENOTYPES = -7;
     public static final int NUMBER_UNKNOWN = -6;

--- a/src/main/java/fr/inserm/u1078/tludwig/vcfprocessor/functions/analysis/SampleStats.java
+++ b/src/main/java/fr/inserm/u1078/tludwig/vcfprocessor/functions/analysis/SampleStats.java
@@ -9,14 +9,13 @@ import fr.inserm.u1078.tludwig.vcfprocessor.genetics.Genotype;
 import fr.inserm.u1078.tludwig.vcfprocessor.genetics.Sample;
 import fr.inserm.u1078.tludwig.vcfprocessor.genetics.Variant;
 import fr.inserm.u1078.tludwig.vcfprocessor.testing.TestingScript;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 
 /**
  * Print Stats about each sample (Mean Depths, TS/TV Het/HomAlt).
  * 
- * @author Thomas E. Ludwig (INSERM - U1078) 
+ * @author Thomas E. Ludwig (INSERM - U1078)
  * Started on             2015-11-23
  * Checked for release on 2020-05-12
  * Unit Test defined on   2020-07-08
@@ -38,7 +37,7 @@ public class SampleStats extends ParallelVCFVariantPedFunction<SampleStats.Analy
 
   private ArrayList<Sample> samples;
 
-  public static final String[] HEADERS = {"Sample","Group","Sites","Genotyped","Missing","%Missing","MeanDepths","Variants", "Singletons","TS","TV","TS/TV","Het","HetRatio","HomAlt","Haploid"};
+  public static final String[] HEADERS = {"Sample", "Group", "Sites", "Genotyped", "Missing", "%Missing", "MeanDepths", "Variants", "Singletons", "TS", "TV", "TS/TV", "Het", "HetRatio", "HomAlt", "Haploid"};
 
   @Override
   public String getSummary() {
@@ -136,11 +135,12 @@ public class SampleStats extends ParallelVCFVariantPedFunction<SampleStats.Analy
       Sample sample = samples.get(s);
       Genotype geno = variant.getGenotype(sample);
       Message.asserts(geno != null, "No genotype found for [" + samples.get(s).getId() + "] " + variant.shortString());
+
       lDepths[s] = geno.getDP(); //changed to get the same results as vcftools and bcftools (take dp of missing genotype, but if dp itself is missing does not fall back on sumAD)
       if (geno.isMissing())
         lMissings[s] = true;
       else {
-        //lDepths[s] = Math.max(geno.getSumAD(), geno.getDP()); //changed to get the same results as vcftools and bcftools
+        // lDepths[s] = Math.max(geno.getSumAD(), geno.getDP()); // changed to get the same results as vcftools and bcftools
         if(geno.isHeterozygousDiploid())
           lHets[s]++;
         if(geno.isHaploid() && geno.hasAlternate())
@@ -151,7 +151,7 @@ public class SampleStats extends ParallelVCFVariantPedFunction<SampleStats.Analy
           if (geno.hasAllele(a)) {
             lVariants[s]++;
             if (1== acs[a])
-            //if (geno.getCount(a) == acs[a]) //check is 1/1 is indeed a singleton
+            // if (geno.getCount(a) == acs[a]) // check is 1/1 is indeed a singleton
               lSingletons[s]++;
             if (tstv.get(a) == Variant.VariantType.TRANSITION)
               lTransitions[s]++;

--- a/src/main/java/fr/inserm/u1078/tludwig/vcfprocessor/functions/vcftransform/SplitMultiAllelic.java
+++ b/src/main/java/fr/inserm/u1078/tludwig/vcfprocessor/functions/vcftransform/SplitMultiAllelic.java
@@ -137,6 +137,11 @@ public class SplitMultiAllelic extends ParallelVCFFunction {
       gt = g[0].split("\\|");
     }
 
+    if(gt.length > 2) {
+      Message.warning("This function can only process a ploidy of 2 maximum");
+      return ".";
+    }
+
     //process GT
     for (int i = 0; i < gt.length; i++){
       if(gt[i].equals(allele+""))
@@ -175,7 +180,10 @@ public class SplitMultiAllelic extends ParallelVCFFunction {
                 Message.warning("Could not split genotype annotation [" + genotype + "] with format [" + format + "] for allele [" + alt + "]");
                 return genotype;
               } else{
-                g[i] = v[0]+","+v[pls.get("0/"+allele)]+","+v[pls.get(allele+"/"+allele)]; //TODO if PL is updated, should GQ be updated also ?, i don't think so, because 1) gq is already affected, 2) genotype will not really change              
+                final boolean haploid = gt.length == 1;
+                g[i] = haploid
+                    ? v[0]+","+v[allele]
+                    : v[0]+","+v[pls.get("0/"+allele)]+","+v[pls.get(allele+"/"+allele)]; //TODO if PL is updated, should GQ be updated also ?, i don't think so, because 1) gq is already affected, 2) genotype will not really change
               }
               break;
             default:

--- a/src/main/java/fr/inserm/u1078/tludwig/vcfprocessor/genetics/Genotype.java
+++ b/src/main/java/fr/inserm/u1078/tludwig/vcfprocessor/genetics/Genotype.java
@@ -144,7 +144,7 @@ public class Genotype {
   }
 
   /**
-   * returns true if all alleles are the same (1, 2 or more chromosomes) and this allele isn't ref
+   * returns true if all alleles are the same (1, 2 or more chromosomes) and this allele isn't ref.
    * @return true if homozygous/haploid to alt
    */
   public boolean isHomozygousOrHaploidToAlt() {

--- a/src/main/resources/CHANGELOG.VCFProcessor.md
+++ b/src/main/resources/CHANGELOG.VCFProcessor.md
@@ -1,3 +1,11 @@
+## 1.2.12 (2026-04-02)
+### core
+### functions
+- **fixed** : `SplitMultiAllelic` : ArrayOutOfBoundException
+### filters
+### graphs
+### other
+
 ## 1.2.11 (2026-03-17)
 ### core
 - **added** : `Message` conditional info/error/waring/fatal...

--- a/src/main/resources/CHANGELOG.VCFProcessor.md
+++ b/src/main/resources/CHANGELOG.VCFProcessor.md
@@ -1,7 +1,8 @@
 ## 1.2.12 (2026-04-02)
 ### core
+- **fixed** : `BCF` : binary representation of ".|." was misinterpreted as ".|-1"
 ### functions
-- **fixed** : `SplitMultiAllelic` : ArrayOutOfBoundException
+- **fixed** : `SplitMultiAllelic` : computation methods for PL etc on haploid genotypes
 ### filters
 ### graphs
 ### other

--- a/src/test/java/fr/inserm/u1078/tludwig/vcfprocessor/test/Sandbox.java
+++ b/src/test/java/fr/inserm/u1078/tludwig/vcfprocessor/test/Sandbox.java
@@ -2,6 +2,7 @@ package fr.inserm.u1078.tludwig.vcfprocessor.test;
 
 import fr.inserm.u1078.tludwig.maok.tools.Message;
 import fr.inserm.u1078.tludwig.vcfprocessor.files.ByteArray;
+import fr.inserm.u1078.tludwig.vcfprocessor.files.variants.BCFByteArray;
 import fr.inserm.u1078.tludwig.vcfprocessor.genetics.Canonical;
 
 import java.nio.ByteBuffer;
@@ -21,7 +22,12 @@ import java.util.List;
 public class Sandbox {
 
   public static void main(String[] args) throws Exception {
-    testDiv();
+    for(int i = 0; i < 256; i++) {
+      int c1 = BCFByteArray.convert(i);
+      int c2 = BCFByteArray.convert2(i);
+      System.out.println(i+"["+c1+"] ["+c2+"]");
+    }
+    //testDiv();
     /*int[] sizes = {1,2,3,4,5,6,7,8,9,15,16,17,20,63,64,65};
     for(int size : sizes)
       divide(size, 4);*/

--- a/src/test/java/fr/inserm/u1078/tludwig/vcfprocessor/test/Sandbox.java
+++ b/src/test/java/fr/inserm/u1078/tludwig/vcfprocessor/test/Sandbox.java
@@ -24,8 +24,7 @@ public class Sandbox {
   public static void main(String[] args) throws Exception {
     for(int i = 0; i < 256; i++) {
       int c1 = BCFByteArray.convert(i);
-      int c2 = BCFByteArray.convert2(i);
-      System.out.println(i+"["+c1+"] ["+c2+"]");
+      System.out.println(i+"["+c1+"]");
     }
     //testDiv();
     /*int[] sizes = {1,2,3,4,5,6,7,8,9,15,16,17,20,63,64,65};


### PR DESCRIPTION
## 1.2.12 (2026-04-02)
### core
- **fixed** : `BCF` : binary representation of ".|." was misinterpreted as ".|-1"
### functions
- **fixed** : `SplitMultiAllelic` : computation methods for PL etc on haploid genotypes
### filters
### graphs
### other